### PR TITLE
Fill.watch: Push diffs only

### DIFF
--- a/src/cache/Readme.md
+++ b/src/cache/Readme.md
@@ -2,4 +2,4 @@
 
 Graffy module providing in-memory caching.
 
-See [Graffy documentation](https://aravindet.github.io/graffy/#/GraffyClient) for more.
+See [Graffy documentation](https://aravindet.github.io/graffy/) for more.

--- a/src/common/graph/sieve.js
+++ b/src/common/graph/sieve.js
@@ -1,6 +1,5 @@
 import { isBranch, isRange, getIndex, getLastIndex } from '../node';
 import { keyAfter, keyBefore } from './step';
-// import merge from './merge';
 
 export default function sieve(current, changes, result = []) {
   let index = 0;
@@ -122,7 +121,6 @@ function updateNode(current, index, change, result) {
 }
 
 function getNewer(node, base) {
-  // const { version } = base;
   if (isBranch(node)) {
     const children = node.children.filter(child => getNewer(child, base));
     return children.length && { ...node, children };

--- a/src/common/graph/sieve.js
+++ b/src/common/graph/sieve.js
@@ -1,5 +1,6 @@
 import { isBranch, isRange, getIndex, getLastIndex } from '../node';
 import { keyAfter, keyBefore } from './step';
+// import merge from './merge';
 
 export default function sieve(current, changes, result = []) {
   let index = 0;
@@ -47,6 +48,8 @@ function mergeRanges(base, node) {
   // assertVersion(node, base.version);
   // eslint-disable-next-line no-param-reassign
   if (node.version < base.version) [node, base] = [base, node];
+  // Ensure node is newer than base
+
   return [
     base.key < node.key && { ...base, end: keyBefore(node.key) },
     node,
@@ -74,7 +77,7 @@ export function insertNode(current, change, result, start = 0) {
 function insertNodeIntoRange(current, index, change, result) {
   const key = change.key;
   const range = current[index];
-  const newChange = getNewer(change, range.version);
+  const newChange = getNewer(change, range);
   if (!newChange) return;
   result.push(newChange);
 
@@ -93,34 +96,39 @@ function updateNode(current, index, change, result) {
   if (isBranch(change) && isBranch(node)) {
     // Both are branches: Recursively merge children.
     const nextResult = [];
+    node.version = change.version;
     sieve(node.children, change.children, nextResult);
     if (nextResult.length) result.push({ ...change, children: nextResult });
   } else if (isBranch(node)) {
     // Current node is a branch but the change is a leaf; if the branch
     // has newer children, ignore the change and keep only those children;
     // Otherwise, discard the branch and keep the change.
-    const newNode = getNewer(node, change.version);
+    const newNode = getNewer(node, change);
     current[index] = newNode || change;
     if (!newNode) result.push(change);
     // TODO: In the case of partial removal, what should result be?
   } else {
     // Current node is a leaf. Replace with the change if it is newer.
-    const newChange = getNewer(change, node.version);
+    const newChange = getNewer(change, node);
     if (newChange) {
       current[index] = newChange;
-      result.push(newChange);
+      // console.log(current);
+      if (change.value !== node.value || change.path !== node.path) {
+        result.push(newChange);
+      }
     }
   }
   return index + 1;
 }
 
-function getNewer(node, version) {
+function getNewer(node, base) {
+  // const { version } = base;
   if (isBranch(node)) {
-    const children = node.children.filter(child => getNewer(child, version));
+    const children = node.children.filter(child => getNewer(child, base));
     return children.length && { ...node, children };
   } else {
     // assertVersion(node, version);
-    return node.version >= version ? node : null;
+    return node.version >= base.version ? node : null;
   }
 }
 

--- a/src/common/graph/slice.js
+++ b/src/common/graph/slice.js
@@ -9,6 +9,7 @@ import {
 import { keyAfter, keyBefore } from './step';
 import { wrap } from '../path';
 import merge from './merge';
+import add from './add';
 
 class Result {
   constructor(root) {
@@ -29,7 +30,7 @@ class Result {
   addLinked(children) {
     if (this.root !== this) return this.root.addLinked(children);
     this.linked = this.linked || [];
-    merge(this.linked, children);
+    add(this.linked, children);
   }
 }
 

--- a/src/common/graph/test/sieve.test.js
+++ b/src/common/graph/test/sieve.test.js
@@ -1,4 +1,4 @@
-import { sieve } from '..';
+import sieve from '../sieve';
 import { makeGraph } from '../../build';
 
 test('empty', () => {
@@ -32,4 +32,11 @@ test('full-add-branch', () => {
     },
     { key: 'foo\0', end: '\uffff', version: 0 },
   ]);
+});
+
+test('ignore-unchanged', () => {
+  const g = makeGraph({ foo: { bar: 42 } }, 0);
+  const change = sieve(g, makeGraph({ foo: { bar: 42 } }, 1));
+  expect(change).toEqual([]);
+  expect(g).toEqual(makeGraph({ foo: { bar: 42 } }, 1));
 });

--- a/src/common/graph/test/slice.test.js
+++ b/src/common/graph/test/slice.test.js
@@ -348,4 +348,42 @@ describe('version', () => {
       { key: 'foo', version: 1580541870611, value: 42 },
     ]);
   });
+
+  test('frozenQueryLinks', () => {
+    expect(
+      slice(
+        [
+          { key: 'bar', version: 0, path: ['foo'] },
+          { key: 'baz', version: 0, path: ['foo'] },
+          {
+            key: 'foo',
+            version: 0,
+            children: [{ key: 'x', version: 0, value: 42 }],
+          },
+        ],
+        [
+          {
+            key: 'bar',
+            version: 0,
+            children: Object.freeze([{ key: 'x', version: 0, value: 1 }]),
+          },
+          {
+            key: 'baz',
+            version: 0,
+            children: Object.freeze([{ key: 'x', version: 0, value: 1 }]),
+          },
+        ],
+      ),
+    ).toEqual({
+      known: [
+        { key: 'bar', version: 0, path: ['foo'] },
+        { key: 'baz', version: 0, path: ['foo'] },
+        {
+          key: 'foo',
+          version: 0,
+          children: [{ key: 'x', version: 0, value: 42 }],
+        },
+      ],
+    });
+  });
 });

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -1,7 +1,3 @@
-// import mergeStreams from 'merge-async-iterators';
-// import { merge, wrap, unwrap, remove, makePath } from '@graffy/common';
-// import { decorate } from '@graffy/common';
-
 import { unwrap } from '@graffy/common';
 
 function resolve(handlers, firstPayload, options) {
@@ -18,7 +14,12 @@ function resolve(handlers, firstPayload, options) {
 
     let nextCalled = false;
     return handle(payload, options, nextPayload => {
-      if (nextCalled) throw Error('resolve.duplicate_next: ' + handle.name);
+      if (nextCalled) {
+        throw Error('resolve.duplicate_next_call: ' + handlers[i].name);
+      }
+      if (typeof nextPayload === 'undefined') {
+        throw Error('resolve.next_without_payload: ' + handlers[i].name);
+      }
       nextCalled = true;
       return run(i + 1, nextPayload);
     });

--- a/src/fill/fill.test.js
+++ b/src/fill/fill.test.js
@@ -4,6 +4,7 @@ import { mockBackend } from '@graffy/testing';
 import fill from './index.js';
 
 const expectNext = async (subscription, expected, version = 0) => {
+  // console.log('assert', expected);
   expect((await subscription.next()).value).toEqual(
     makeGraph(expected, version),
   );
@@ -95,7 +96,7 @@ describe('changes', () => {
       foo: link(['bar', 'b']),
       bar: { b: { x: 5 } },
     });
-    backend.write(makeGraph({ bar: { a: { x: 7 } } })); // Should not be se, 0nt!
+    backend.write(makeGraph({ bar: { a: { x: 7 } } })); // Should not be sent!
     backend.write(makeGraph({ bar: { b: { x: 3 } } }, 0));
     await expectNext(subscription, { bar: { b: { x: 3 } } });
   });
@@ -222,7 +223,7 @@ describe('values', () => {
       subscription,
       // prettier-ignore
       [
-        { key: 'foo', version: 0, children: [
+        { key: 'foo', version: 1, children: [
           { key: '', end: '`\uffff', version: 0 },
           { key: 'a', value: 1, version: 0 },
           { key: 'a\0', end: 'a\uffff', version: 0},
@@ -254,7 +255,7 @@ describe('values', () => {
       subscription,
       // prettier-ignore
       [
-        { key: 'foo', version: 0, children: [
+        { key: 'foo', version: 1, children: [
           { key: '', end: '`\uffff', version: 0 },
           { key: 'a', value: 1, version: 0 },
           { key: 'a\0', end: 'a\uffff', version: 0},
@@ -295,7 +296,7 @@ describe('values', () => {
       subscription,
       // prettier-ignore
       [
-        { key: 'foo', version: 0, children: [
+        { key: 'foo', version: 1, children: [
           { key: 'b', version: 1, value: 2 },
           { key: 'b\0', end: 'c', version: 1 },
           { key: 'c\0', end: 'c\uffff', version: 0 },
@@ -371,19 +372,22 @@ describe('values', () => {
         1,
       ),
     );
-    await expectNext(subscription, {
-      users: {
-        '1': { name: 'alice' },
-        '3': { name: 'carol' },
-      },
-      usersByAge: [
-        { key: '4', path: ['users', '1'], version: 0 },
-        { key: '4\0', end: '4\uffff', version: 0 },
-        { key: '5', end: '5', version: 1 },
-        { key: '5\0', end: '6\uffff', version: 0 },
-        { key: '7', path: ['users', '3'], version: 0 },
-        { key: '7\0', end: '\uffff', version: 0 },
+    await expectNext(
+      subscription,
+      // prettier-ignore
+      [{ key: 'users', version: 1, children: makeGraph({
+          '1': { name: 'alice' },
+          '3': { name: 'carol' },
+        }, 0)},
+        { key: 'usersByAge', version: 1, children: [
+          { key: '4', path: ['users', '1'], version: 0 },
+          { key: '4\0', end: '4\uffff', version: 0 },
+          { key: '5', end: '5', version: 1 },
+          { key: '5\0', end: '6\uffff', version: 0 },
+          { key: '7', path: ['users', '3'], version: 0 },
+          { key: '7\0', end: '\uffff', version: 0 },
+        ]}
       ],
-    });
+    );
   });
 });

--- a/src/fill/index.test.js
+++ b/src/fill/index.test.js
@@ -88,11 +88,14 @@ test('indexes', async () => {
   expect((await subscription.next()).value).toEqual(
     makeGraph(
       {
-        bar: {
-          1: { x: 1 },
-          3: { x: 3 },
-          4: { x: 4 },
-        },
+        bar: makeGraph(
+          {
+            1: { x: 1 },
+            3: { x: 3 },
+            4: { x: 4 },
+          },
+          0,
+        ),
         foo: [
           { key: '', end: '`\uffff', version: 0 },
           { key: 'a', path: ['bar', '1'], version: 0 },
@@ -104,7 +107,7 @@ test('indexes', async () => {
           { key: 'd', path: ['bar', '4'], version: 0 },
         ],
       },
-      0,
+      1,
     ),
   );
 });

--- a/src/fill/subscribe.js
+++ b/src/fill/subscribe.js
@@ -61,7 +61,7 @@ export default function subscribe(store, originalQuery, raw) {
 
   function putValue(value, isChange) {
     if (typeof value === 'undefined') return;
-    // console.log('Fill/subscribe: PutValue', value);
+    // console.log('Fill/subscribe: PutValue', debug(value));
 
     if (value === null) {
       // No results exist at this moment.
@@ -73,7 +73,7 @@ export default function subscribe(store, originalQuery, raw) {
     if (isChange) {
       // console.log('Data before sieve', debug(data), debug(value));
       const sieved = sieve(data, value);
-      // console.log('Data after sieve', debug(data));
+      // console.log('Data after sieve', debug(data), debug(sieved));
       if (!sieved.length) return;
       merge(payload, sieved);
     } else {
@@ -104,7 +104,7 @@ export default function subscribe(store, originalQuery, raw) {
 
     // This is not an else; previous block might update unknown.
     if (!unknown) {
-      // console.log('Pushing', payload);
+      // console.log('Pushing', debug(payload));
       push(raw ? payload : data);
       payload = [];
     }


### PR DESCRIPTION
Previously, watch would yield a new value whenever the upstream provider yielded a value that overlapped with the currently watched tree.

Now, we yield a value only when the value from upstream is actually different from the current value.