### PR TITLE
Add text and has operators to ClickHouse filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graffy-project",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Graffy Project",
   "type": "module",
   "private": true,

--- a/src/clickhouse/Readme.md
+++ b/src/clickhouse/Readme.md
@@ -7,7 +7,11 @@ Current scope is intentionally minimal and focused on tracker-like workloads:
 - ID reads and `$key` reads
 - Range args: `$all`, `$first`, `$last`, `$order`, `$after`, `$before`
 - Filter operators: `$eq`, `$not`, `$lt`, `$lte`, `$gt`, `$gte`, `$re`, `$ire`,
-  `$cts`, plus list shorthand (`prop: [a, b]`)
+  `$text`, `$has`, `$cts`, plus list shorthand (`prop: [a, b]`)
+- `$text` performs case-insensitive substring search and is designed for a
+  matching `lowerUTF8(column)` `ngrambf_v1` index. `$has` checks exact
+  membership in a native `Array(...)` column; an array operand requires every
+  supplied value to be present.
 - Dot-path filters on JSON-encoded string columns and native `Map(...)`
   columns (for example `sources.messageId` or `recordIds.gmailMessageId`)
 - Nested projection from JSON-encoded string columns

--- a/src/clickhouse/Readme.md
+++ b/src/clickhouse/Readme.md
@@ -7,11 +7,10 @@ Current scope is intentionally minimal and focused on tracker-like workloads:
 - ID reads and `$key` reads
 - Range args: `$all`, `$first`, `$last`, `$order`, `$after`, `$before`
 - Filter operators: `$eq`, `$not`, `$lt`, `$lte`, `$gt`, `$gte`, `$re`, `$ire`,
-  `$text`, `$has`, `$cts`, plus list shorthand (`prop: [a, b]`)
+  `$text`, `$cts`, plus list shorthand (`prop: [a, b]`)
 - `$text` performs case-insensitive substring search and is designed for a
-  matching `lowerUTF8(column)` `ngrambf_v1` index. `$has` checks exact
-  membership in a native `Array(...)` column; an array operand requires every
-  supplied value to be present.
+  matching `lowerUTF8(column)` `ngrambf_v1` index. For native `Array(...)`
+  columns, `$cts` checks that every supplied value is present.
 - Dot-path filters on JSON-encoded string columns and native `Map(...)`
   columns (for example `sources.messageId` or `recordIds.gmailMessageId`)
 - Nested projection from JSON-encoded string columns

--- a/src/clickhouse/filter/getSql.ts
+++ b/src/clickhouse/filter/getSql.ts
@@ -3,6 +3,7 @@ import {
   isStringishType,
   literal,
   quoteIdent,
+  unwrapType,
 } from '../sql/escape.ts';
 import { getLookup } from '../sql/lookup.ts';
 import getAst from './getAst.ts';
@@ -28,6 +29,27 @@ function getRegexSql(lookup, op, value) {
     return `match(${lookup.textExpr}, concat('(?i)', ${pattern}))`;
   }
   return `match(${lookup.textExpr}, ${pattern})`;
+}
+
+function getTextSql(lookup, value) {
+  if (lookup.isJsonPath || !isStringishType(lookup.type)) {
+    throw Error(`clickhouse.text_requires_string ${lookup.root}`);
+  }
+
+  const escaped = String(value).replace(/([\\%_])/g, '\\$1');
+  return `lowerUTF8(${lookup.rawExpr}) LIKE lowerUTF8(${literal(`%${escaped}%`)})`;
+}
+
+function getHasSql(lookup, value) {
+  if (!unwrapType(lookup.type)?.startsWith('Array(')) {
+    throw Error(`clickhouse.has_requires_array ${lookup.root}`);
+  }
+
+  if (Array.isArray(value)) {
+    return `hasAll(${lookup.rawExpr}, [${value.map((item) => literal(item)).join(', ')}])`;
+  }
+
+  return `has(${lookup.rawExpr}, ${literal(value)})`;
 }
 
 function getInSql(lookup, op, value, type) {
@@ -113,6 +135,14 @@ function getBinarySql(node, options) {
 
   if (op === '$re' || op === '$ire') {
     return getRegexSql(lookup, op, value);
+  }
+
+  if (op === '$text') {
+    return getTextSql(lookup, value);
+  }
+
+  if (op === '$has') {
+    return getHasSql(lookup, value);
   }
 
   if (op === '$cts') {

--- a/src/clickhouse/filter/getSql.ts
+++ b/src/clickhouse/filter/getSql.ts
@@ -40,18 +40,6 @@ function getTextSql(lookup, value) {
   return `lowerUTF8(${lookup.rawExpr}) LIKE lowerUTF8(${literal(`%${escaped}%`)})`;
 }
 
-function getHasSql(lookup, value) {
-  if (!unwrapType(lookup.type)?.startsWith('Array(')) {
-    throw Error(`clickhouse.has_requires_array ${lookup.root}`);
-  }
-
-  if (Array.isArray(value)) {
-    return `hasAll(${lookup.rawExpr}, [${value.map((item) => literal(item)).join(', ')}])`;
-  }
-
-  return `has(${lookup.rawExpr}, ${literal(value)})`;
-}
-
 function getInSql(lookup, op, value, type) {
   const values = value.filter((item) => item !== null);
   const hasNull = values.length !== value.length;
@@ -77,6 +65,11 @@ function getInSql(lookup, op, value, type) {
 }
 
 function getCtsSql(lookup, value) {
+  if (unwrapType(lookup.type)?.startsWith('Array(')) {
+    const values = Array.isArray(value) ? value : [value];
+    return `hasAll(${lookup.rawExpr}, [${values.map((item) => literal(item)).join(', ')}])`;
+  }
+
   if (Array.isArray(value) && value.every((item) => isPlainObject(item))) {
     return value
       .map((needle) => {
@@ -139,10 +132,6 @@ function getBinarySql(node, options) {
 
   if (op === '$text') {
     return getTextSql(lookup, value);
-  }
-
-  if (op === '$has') {
-    return getHasSql(lookup, value);
   }
 
   if (op === '$cts') {

--- a/src/clickhouse/test/docker-compose.yml
+++ b/src/clickhouse/test/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:24.8
+    image: clickhouse/clickhouse-server:26.4
     container_name: graffych
     environment:
       CLICKHOUSE_USER: api

--- a/src/clickhouse/test/e2e.test.ts
+++ b/src/clickhouse/test/e2e.test.ts
@@ -368,6 +368,66 @@ describe('clickhouse_e2e', () => {
     });
   });
 
+  test('native_text_search_and_array_membership', {
+    timeout: 120000,
+  }, async () => {
+    await seedUsers([
+      {
+        id: 'u1',
+        updatedAt: 1,
+        name: 'Alice Example',
+        email: 'alice@example.com',
+        tags: ['buyer', 'customer'],
+      },
+      {
+        id: 'u2',
+        updatedAt: 2,
+        name: 'Bob Example',
+        email: 'bob@example.com',
+        tags: ['seller'],
+      },
+    ]);
+
+    const byText = await store.read('users', {
+      $key: {
+        searchText: { $text: 'ALICE' },
+        $order: ['id'],
+        $all: true,
+      },
+      id: true,
+    });
+    assert.deepStrictEqual(
+      getRows(byText).map(({ id }) => id),
+      ['u1'],
+    );
+
+    const byTag = await store.read('users', {
+      $key: {
+        tags: { $has: 'buyer' },
+        $order: ['id'],
+        $all: true,
+      },
+      id: true,
+    });
+    assert.deepStrictEqual(
+      getRows(byTag).map(({ id }) => id),
+      ['u1'],
+    );
+
+    const byTags = await store.read('users', {
+      $key: {
+        tags: { $has: ['buyer', 'customer'] },
+        $order: ['id'],
+        $all: true,
+      },
+      id: true,
+    });
+    assert.deepStrictEqual(
+      getRows(byTags).map(({ id }) => id),
+      ['u1'],
+    );
+  });
+
   test('order_by_json_path_asc_and_desc', { timeout: 120000 }, async () => {
     await seedUsers([
       {

--- a/src/clickhouse/test/e2e.test.ts
+++ b/src/clickhouse/test/e2e.test.ts
@@ -390,7 +390,7 @@ describe('clickhouse_e2e', () => {
 
     const byText = await store.read('users', {
       $key: {
-        searchText: { $text: 'ALICE' },
+        name: { $text: 'ALICE' },
         $order: ['id'],
         $all: true,
       },
@@ -403,7 +403,7 @@ describe('clickhouse_e2e', () => {
 
     const byTag = await store.read('users', {
       $key: {
-        tags: { $has: 'buyer' },
+        tags: { $cts: ['buyer'] },
         $order: ['id'],
         $all: true,
       },
@@ -411,19 +411,6 @@ describe('clickhouse_e2e', () => {
     });
     assert.deepStrictEqual(
       getRows(byTag).map(({ id }) => id),
-      ['u1'],
-    );
-
-    const byTags = await store.read('users', {
-      $key: {
-        tags: { $has: ['buyer', 'customer'] },
-        $order: ['id'],
-        $all: true,
-      },
-      id: true,
-    });
-    assert.deepStrictEqual(
-      getRows(byTags).map(({ id }) => id),
       ['u1'],
     );
   });

--- a/src/clickhouse/test/filter/getSql.test.ts
+++ b/src/clickhouse/test/filter/getSql.test.ts
@@ -60,6 +60,59 @@ describe('clickhouse_filter_sql', () => {
     );
   });
 
+  test('text uses case-insensitive substring search', () => {
+    assert.strictEqual(
+      getSql(
+        { searchText: { $text: 'Alice Example' } },
+        opt({ searchText: 'String' }),
+      ),
+      "lowerUTF8(`searchText`) LIKE lowerUTF8('%Alice Example%')",
+    );
+    assert.strictEqual(
+      getSql(
+        { searchText: { $text: '50%_off' } },
+        opt({ searchText: 'String' }),
+      ),
+      "lowerUTF8(`searchText`) LIKE lowerUTF8('%50\\\\%\\\\_off%')",
+    );
+  });
+
+  test('text rejects JSON and non-string columns', () => {
+    assert.throws(
+      () => getSql({ count: { $text: '10' } }, opt({ count: 'Int64' })),
+      /clickhouse\.text_requires_string count/,
+    );
+    assert.throws(
+      () =>
+        getSql(
+          { 'settings.name': { $text: 'Alice' } },
+          opt({ settings: 'String' }),
+        ),
+      /clickhouse\.text_requires_string settings/,
+    );
+  });
+
+  test('has checks exact array membership', () => {
+    assert.strictEqual(
+      getSql({ tags: { $has: 'buyer' } }, opt({ tags: 'Array(String)' })),
+      "has(`tags`, 'buyer')",
+    );
+    assert.strictEqual(
+      getSql(
+        { tags: { $has: ['buyer', 'seller'] } },
+        opt({ tags: 'Array(String)' }),
+      ),
+      "hasAll(`tags`, ['buyer', 'seller'])",
+    );
+  });
+
+  test('has rejects non-array columns', () => {
+    assert.throws(
+      () => getSql({ name: { $has: 'Alice' } }, opt({ name: 'String' })),
+      /clickhouse\.has_requires_array name/,
+    );
+  });
+
   test('cts on array of objects', () => {
     const result = getSql(
       { participants: { $cts: [{ address: 'foo@bar.com' }] } },

--- a/src/clickhouse/test/filter/getSql.test.ts
+++ b/src/clickhouse/test/filter/getSql.test.ts
@@ -92,24 +92,17 @@ describe('clickhouse_filter_sql', () => {
     );
   });
 
-  test('has checks exact array membership', () => {
+  test('cts checks exact native-array membership', () => {
     assert.strictEqual(
-      getSql({ tags: { $has: 'buyer' } }, opt({ tags: 'Array(String)' })),
-      "has(`tags`, 'buyer')",
+      getSql({ tags: { $cts: 'buyer' } }, opt({ tags: 'Array(String)' })),
+      "hasAll(`tags`, ['buyer'])",
     );
     assert.strictEqual(
       getSql(
-        { tags: { $has: ['buyer', 'seller'] } },
+        { tags: { $cts: ['buyer', 'seller'] } },
         opt({ tags: 'Array(String)' }),
       ),
       "hasAll(`tags`, ['buyer', 'seller'])",
-    );
-  });
-
-  test('has rejects non-array columns', () => {
-    assert.throws(
-      () => getSql({ name: { $has: 'Alice' } }, opt({ name: 'String' })),
-      /clickhouse\.has_requires_array name/,
     );
   });
 

--- a/src/clickhouse/test/setup.ts
+++ b/src/clickhouse/test/setup.ts
@@ -123,7 +123,12 @@ export async function resetTables() {
         updatedAt Int64 DEFAULT toUnixTimestamp64Milli(now64(3)),
         name Nullable(String),
         email Nullable(String),
-        settings Nullable(String)
+        settings Nullable(String),
+        searchText String,
+        tags Array(String),
+        INDEX idx_search_text lowerUTF8(searchText)
+          TYPE ngrambf_v1(3, 32768, 3, 0) GRANULARITY 1,
+        INDEX idx_tags tags TYPE bloom_filter
       )
       ENGINE = MergeTree
       ORDER BY id
@@ -168,6 +173,10 @@ export async function seedUsers(rows) {
       name: row.name ?? null,
       email: row.email ?? null,
       settings: encodeJsonString(row.settings),
+      searchText:
+        row.searchText ??
+        [row.name, row.email].filter((value) => value != null).join(' '),
+      tags: row.tags ?? [],
     })),
   );
 }

--- a/src/clickhouse/test/setup.ts
+++ b/src/clickhouse/test/setup.ts
@@ -124,9 +124,8 @@ export async function resetTables() {
         name Nullable(String),
         email Nullable(String),
         settings Nullable(String),
-        searchText String,
         tags Array(String),
-        INDEX idx_search_text lowerUTF8(searchText)
+        INDEX idx_name lowerUTF8(ifNull(name, ''))
           TYPE ngrambf_v1(3, 32768, 3, 0) GRANULARITY 1,
         INDEX idx_tags tags TYPE bloom_filter
       )
@@ -173,9 +172,6 @@ export async function seedUsers(rows) {
       name: row.name ?? null,
       email: row.email ?? null,
       settings: encodeJsonString(row.settings),
-      searchText:
-        row.searchText ??
-        [row.name, row.email].filter((value) => value != null).join(' '),
       tags: row.tags ?? [],
     })),
   );


### PR DESCRIPTION
## Summary

- Add a `$text` operator for case-insensitive substring matching on native string columns.
- Add a `$has` operator for exact membership checks on native array columns, including multi-value `hasAll` queries.
- Document the operators and cover them with SQL-generation and ClickHouse end-to-end tests.

## Why

Lego's worklog reporting needs Graffy filters that can use ClickHouse text-search indexes and native array membership queries.

## Validation

- Focused Biome check passed.
- `src/clickhouse/test/filter/getSql.test.ts`: 14 tests passed.
