### PR TITLE
Add ClickHouse projection pushdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graffy-project",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Graffy Project",
   "type": "module",
   "private": true,

--- a/src/clickhouse/Db.ts
+++ b/src/clickhouse/Db.ts
@@ -20,7 +20,7 @@ import {
   literal,
   quoteIdent,
 } from './sql/escape.ts';
-import { selectByArgs, selectByIds } from './sql/select.ts';
+import { mergeProjections, selectByArgs, selectByIds } from './sql/select.ts';
 
 function maybeParseJson(value) {
   if (typeof value !== 'string') return value;
@@ -284,7 +284,20 @@ export default class Db {
     };
 
     const getByIds = async () => {
-      const selection = selectByIds(Object.keys(idQueries), tableOptions);
+      let projection: Record<string, any> | null = {};
+      for (const children of Object.values(idQueries)) {
+        if (!children) {
+          projection = null;
+          break;
+        }
+        projection = mergeProjections(projection, decodeQuery(children));
+      }
+
+      const selection = selectByIds(
+        Object.keys(idQueries),
+        projection,
+        tableOptions,
+      );
       const rows = await this.query(selection.sql);
       for (const row of rows) {
         const object = this.normalizeRow(row, tableOptions.schema);

--- a/src/clickhouse/Readme.md
+++ b/src/clickhouse/Readme.md
@@ -13,7 +13,11 @@ Current scope is intentionally minimal and focused on tracker-like workloads:
   columns, `$cts` checks that every supplied value is present.
 - Dot-path filters on JSON-encoded string columns and native `Map(...)`
   columns (for example `sources.messageId` or `recordIds.gmailMessageId`)
-- Nested projection from JSON-encoded string columns
+- Projection pushdown for ID and `$key` reads. Graffy selects only requested
+  columns plus the ID, version, and ordering values needed for read metadata
+  and pagination. Nested projections on JSON-encoded strings use
+  `JSONExtractRaw`; native `JSON` projections read direct subcolumns. Both are
+  rebuilt into the requested nested shape before decoding.
 - Join filters via subqueries (for example `$key: { syncJob: { ... } }`)
 - Aggregates: `$count`, `$sum`, `$avg`, `$max`, `$min`, `$card` with
   `$group: true` and `$group: [..]`

--- a/src/clickhouse/sql/select.ts
+++ b/src/clickhouse/sql/select.ts
@@ -1,4 +1,10 @@
-import { literal, quoteIdent } from './escape.ts';
+import {
+  isPlainObject,
+  isStringishType,
+  literal,
+  quoteIdent,
+  unwrapType,
+} from './escape.ts';
 import getArgSql from './getArgSql.ts';
 import { getLookup } from './lookup.ts';
 
@@ -15,6 +21,100 @@ const aggOpOrder = ['$sum', '$avg', '$max', '$min', '$card'];
 function getTableSql({ database = 'default', table, final = false }) {
   const tableSql = `${quoteIdent(database)}.${quoteIdent(table)}`;
   return final ? `${tableSql} FINAL` : tableSql;
+}
+
+export function mergeProjections(current, incoming) {
+  if (current === true || incoming === true) return true;
+  if (!isPlainObject(current)) return incoming;
+  if (!isPlainObject(incoming)) return current;
+
+  const merged = { ...current };
+  Object.entries(incoming).forEach(([key, value]) => {
+    merged[key] = key in merged ? mergeProjections(merged[key], value) : value;
+  });
+  return merged;
+}
+
+function nestProjection(path, value) {
+  return path.reduceRight((child, key) => ({ [key]: child }), value);
+}
+
+function isNativeJsonType(type) {
+  const unwrapped = unwrapType(type);
+  return (
+    unwrapped === 'JSON' ||
+    unwrapped?.startsWith('JSON(') ||
+    unwrapped === "Object('json')"
+  );
+}
+
+function getJsonLeafSql(root, path, options) {
+  const type = options.schema.types[root];
+  if (isNativeJsonType(type)) {
+    const subcolumn = [root, ...path].map(quoteIdent).join('.');
+    return `ifNull(toJSONString(${subcolumn}), 'null')`;
+  }
+
+  if (isStringishType(type)) {
+    const pathArgs = path.map((part) => literal(part)).join(', ');
+    const raw = `JSONExtractRaw(ifNull(${quoteIdent(root)}, '{}'), ${pathArgs})`;
+    return `ifNull(nullIf(${raw}, ''), 'null')`;
+  }
+
+  throw Error(`clickhouse.projection_requires_json ${root}`);
+}
+
+function getNestedJsonSql(root, projection, path, options) {
+  const parts = [literal('{')];
+  let count = 0;
+
+  Object.entries(projection).forEach(([key, value]) => {
+    if (key[0] === '$' || (value !== true && !isPlainObject(value))) return;
+    if (count) parts.push(literal(','));
+    parts.push(literal(`${JSON.stringify(key)}:`));
+    parts.push(
+      value === true
+        ? getJsonLeafSql(root, [...path, key], options)
+        : getNestedJsonSql(root, value, [...path, key], options),
+    );
+    count += 1;
+  });
+
+  parts.push(literal('}'));
+  return `concat(${parts.join(', ')})`;
+}
+
+function getProjectionSelectSql(projection, options, orderSpec = []) {
+  if (!projection) return '*';
+
+  const roots = new Map<string, any>();
+  const addProjection = (rawProp, value) => {
+    const prop = rawProp[0] === '!' ? rawProp.slice(1) : rawProp;
+    const [root, ...path] = prop.split('.');
+    getLookup(root, options);
+    const incoming = path.length ? nestProjection(path, value) : value;
+    roots.set(
+      root,
+      roots.has(root) ? mergeProjections(roots.get(root), incoming) : incoming,
+    );
+  };
+
+  Object.entries(projection).forEach(([prop, value]) => {
+    if (prop[0] !== '$' && (value === true || isPlainObject(value))) {
+      addProjection(prop, value);
+    }
+  });
+  [options.idCol, options.verCol, ...orderSpec].forEach((prop) => {
+    addProjection(prop, true);
+  });
+
+  return [...roots.entries()]
+    .map(([root, value]) =>
+      value === true
+        ? quoteIdent(root)
+        : `CAST(${getNestedJsonSql(root, value, [], options)}, 'JSON') AS ${quoteIdent(root)}`,
+    )
+    .join(', ');
 }
 
 function getAggregateSelectSql(projection, options, groupSpec) {
@@ -60,7 +160,10 @@ function getAggregateSelectSql(projection, options, groupSpec) {
 }
 
 export function selectByArgs(args, projection, options) {
-  const { where, order, limit, groupSpec, ...rest } = getArgSql(args, options);
+  const { where, order, limit, groupSpec, orderSpec, ...rest } = getArgSql(
+    args,
+    options,
+  );
   const whereClause = where.length ? ` WHERE ${where.join(' AND ')}` : '';
   const orderClause = order ? ` ORDER BY ${order}` : '';
 
@@ -78,10 +181,11 @@ export function selectByArgs(args, projection, options) {
       order,
       limit,
       groupSpec,
+      orderSpec,
       isAggregate: false,
       aggregateAliases: {},
       groupAliases: [],
-      sql: `SELECT * FROM ${getTableSql(options)}${whereClause}${orderClause} LIMIT ${limit}`,
+      sql: `SELECT ${getProjectionSelectSql(projection, options, orderSpec)} FROM ${getTableSql(options)}${whereClause}${orderClause} LIMIT ${limit}`,
     };
   }
 
@@ -97,6 +201,7 @@ export function selectByArgs(args, projection, options) {
     order,
     limit,
     groupSpec,
+    orderSpec,
     isAggregate: true,
     aggregateAliases,
     groupAliases,
@@ -104,11 +209,11 @@ export function selectByArgs(args, projection, options) {
   };
 }
 
-export function selectByIds(ids, options) {
+export function selectByIds(ids, projection, options) {
   const where = [
     `${quoteIdent(options.idCol)} IN (${ids.map((id) => literal(id)).join(', ')})`,
   ];
   return {
-    sql: `SELECT * FROM ${getTableSql(options)} WHERE ${where.join(' AND ')}`,
+    sql: `SELECT ${getProjectionSelectSql(projection, options)} FROM ${getTableSql(options)} WHERE ${where.join(' AND ')}`,
   };
 }

--- a/src/clickhouse/test/db/dbRead.test.ts
+++ b/src/clickhouse/test/db/dbRead.test.ts
@@ -88,6 +88,7 @@ describe('clickhouse_db_read', () => {
             createdAt: 'Int64',
             name: 'String',
             email: 'String',
+            settings: 'Nullable(String)',
           },
         },
         joins: {
@@ -132,9 +133,11 @@ describe('clickhouse_db_read', () => {
 
     assert.deepStrictEqual(result, { data: { subject: 'Hello' } });
     assert.strictEqual(mockQuery.mock.callCount(), 1);
-    assert.ok(
-      getSqlFromCall(mockQuery.mock.calls[0]).includes("WHERE `id` IN ('m1')"),
-    );
+    const sql = getSqlFromCall(mockQuery.mock.calls[0]);
+    assert.ok(sql.includes("JSONExtractRaw(ifNull(`data`, '{}'), 'subject')"));
+    assert.ok(sql.includes("'JSON') AS `data`, `id`, `updatedAt`"));
+    assert.ok(sql.includes("WHERE `id` IN ('m1')"));
+    assert.ok(!sql.includes('SELECT *'));
   });
 
   test('range_read_with_cts_and_nested_projection', async () => {
@@ -180,7 +183,43 @@ describe('clickhouse_db_read', () => {
     })) {
       assert.deepStrictEqual(result[0].$key[k], v);
     }
-    assert.ok(getSqlFromCall(mockQuery.mock.calls[0]).includes('arrayExists'));
+    const sql = getSqlFromCall(mockQuery.mock.calls[0]);
+    assert.ok(sql.includes('arrayExists'));
+    for (const column of ['id', 'data', 'participants', 'updatedAt']) {
+      assert.ok(sql.includes(`\`${column}\``));
+    }
+    assert.ok(!sql.includes('SELECT *'));
+    assert.ok(!sql.includes('`createdAt`'));
+  });
+
+  test('id_lookups_merge_nested_projections', async () => {
+    mockQuery.mock.mockImplementationOnce(async () => ({
+      json: async () => [
+        {
+          id: 'u1',
+          updatedAt: 100,
+          settings: '{"foo":1}',
+        },
+        {
+          id: 'u2',
+          updatedAt: 101,
+          settings: '{"bar":{"baz":2}}',
+        },
+      ],
+    }));
+
+    await store.read('users', [
+      { $key: 'u1', settings: { foo: true } },
+      { $key: 'u2', settings: { bar: { baz: true } } },
+    ]);
+
+    assert.strictEqual(mockQuery.mock.callCount(), 1);
+    const sql = getSqlFromCall(mockQuery.mock.calls[0]);
+    assert.ok(sql.includes("JSONExtractRaw(ifNull(`settings`, '{}'), 'foo')"));
+    assert.ok(
+      sql.includes("JSONExtractRaw(ifNull(`settings`, '{}'), 'bar', 'baz')"),
+    );
+    assert.ok(sql.includes("WHERE `id` IN ('u1', 'u2')"));
   });
 
   test('aggregate_group_true_count_and_sum', async () => {
@@ -321,6 +360,11 @@ describe('clickhouse_db_read', () => {
     assert.ok(
       getSqlFromCall(mockQuery.mock.calls[0]).includes(
         'IN (SELECT `authorId` FROM `default`.`posts`',
+      ),
+    );
+    assert.ok(
+      getSqlFromCall(mockQuery.mock.calls[0]).includes(
+        'SELECT `name`, `id`, `updatedAt`',
       ),
     );
   });

--- a/src/clickhouse/test/e2e.test.ts
+++ b/src/clickhouse/test/e2e.test.ts
@@ -345,6 +345,22 @@ describe('clickhouse_e2e', () => {
     assert.strictEqual(filtered[1].id, 'w2');
     assert.strictEqual(filtered[1].code, 'sf_sync_read');
     assert.strictEqual(filtered[1].data.stage, 'written_to_clickhouse');
+
+    const nestedProjection = await store.read('workLogJson.w2', {
+      data: {
+        nested: {
+          source: true,
+        },
+      },
+    });
+
+    assert.deepStrictEqual(nestedProjection, {
+      data: {
+        nested: {
+          source: 'lego',
+        },
+      },
+    });
   });
 
   test('id_lookup_with_nested_projection', { timeout: 120000 }, async () => {

--- a/src/clickhouse/test/sql/select.test.ts
+++ b/src/clickhouse/test/sql/select.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { selectByArgs, selectByIds } from '../../sql/select.ts';
+import {
+  mergeProjections,
+  selectByArgs,
+  selectByIds,
+} from '../../sql/select.ts';
 
 function normalize(sql) {
   return sql
@@ -19,7 +23,9 @@ describe('clickhouse_select_sql', () => {
         id: 'String',
         updatedAt: 'Int64',
         isDeleted: 'UInt8',
+        name: 'String',
         participants: 'Nullable(String)',
+        nativeData: 'JSON',
       },
     },
   };
@@ -47,7 +53,7 @@ describe('clickhouse_select_sql', () => {
   });
 
   test('selectByIds', () => {
-    const { sql } = selectByIds(['a', 'b'], options);
+    const { sql } = selectByIds(['a', 'b'], null, options);
     assert.strictEqual(
       normalize(sql),
       normalize(`
@@ -58,13 +64,156 @@ describe('clickhouse_select_sql', () => {
   });
 
   test('selectByIds_with_explicit_final', () => {
-    const { sql } = selectByIds(['a'], { ...options, final: true });
+    const { sql } = selectByIds(['a'], null, {
+      ...options,
+      final: true,
+    });
     assert.strictEqual(
       normalize(sql),
       normalize(`
         SELECT * FROM \`default\`.\`user\` FINAL
         WHERE \`id\` IN ('a')
       `),
+    );
+  });
+
+  test('selectByArgs_pushes_projection_and_cursor_columns', () => {
+    const { sql } = selectByArgs(
+      {
+        $order: ['isDeleted'],
+        $first: 10,
+      },
+      {
+        name: true,
+        participants: { address: true },
+      },
+      options,
+    );
+
+    assert.ok(
+      normalize(sql).includes(
+        normalize(`
+          SELECT \`name\`, CAST(concat(
+            '{', '"address":',
+            ifNull(nullIf(JSONExtractRaw(
+              ifNull(\`participants\`, '{}'), 'address'
+            ), ''), 'null'), '}'
+          ), 'JSON') AS \`participants\`,
+          \`id\`, \`updatedAt\`, \`isDeleted\`
+        `),
+      ),
+    );
+    assert.ok(normalize(sql).includes('ORDER BY `isDeleted` ASC LIMIT 10'));
+  });
+
+  test('selectByIds_pushes_projection_and_metadata_columns', () => {
+    const { sql } = selectByIds(
+      ['a', 'b'],
+      {
+        participants: { address: true },
+      },
+      options,
+    );
+
+    assert.ok(
+      normalize(sql).includes(
+        normalize(`
+          CAST(concat(
+            '{', '"address":',
+            ifNull(nullIf(JSONExtractRaw(
+              ifNull(\`participants\`, '{}'), 'address'
+            ), ''), 'null'), '}'
+          ), 'JSON') AS \`participants\`
+        `),
+      ),
+    );
+    assert.ok(
+      normalize(sql).includes(
+        normalize(`
+          \`id\`, \`updatedAt\`
+          FROM \`default\`.\`user\`
+          WHERE \`id\` IN ('a', 'b')
+        `),
+      ),
+    );
+  });
+
+  test('native_json_projection_reads_only_requested_subcolumn', () => {
+    const { sql } = selectByArgs(
+      { $order: ['id'], $all: true },
+      {
+        nativeData: {
+          foo: { bar: { baz: true } },
+        },
+      },
+      options,
+    );
+
+    assert.ok(
+      normalize(sql).includes(
+        normalize(`
+          ifNull(
+            toJSONString(\`nativeData\`.\`foo\`.\`bar\`.\`baz\`),
+            'null'
+          )
+        `),
+      ),
+    );
+    assert.ok(sql.includes("'JSON') AS `nativeData`"));
+    assert.ok(!normalize(sql).includes('SELECT `nativeData`'));
+  });
+
+  test('nested_order_path_is_added_to_partial_json_projection', () => {
+    const { sql } = selectByArgs(
+      { $order: ['participants.cursor.rank'], $first: 10 },
+      { participants: { address: true } },
+      options,
+    );
+
+    assert.ok(
+      normalize(sql).includes(
+        normalize(`
+          JSONExtractRaw(
+            ifNull(\`participants\`, '{}'), 'cursor', 'rank'
+          )
+        `),
+      ),
+    );
+    assert.ok(
+      normalize(sql).includes(
+        normalize(`
+          ORDER BY JSONExtractString(
+            ifNull(\`participants\`, '{}'), 'cursor', 'rank'
+          ) ASC
+        `),
+      ),
+    );
+  });
+
+  test('projection_unknown_column_throws', () => {
+    assert.throws(
+      () => selectByArgs({ $all: true }, { missing: true }, options),
+      /clickhouse.no_column missing/,
+    );
+  });
+
+  test('mergeProjections_combines_nested_id_read_shapes', () => {
+    assert.deepStrictEqual(
+      mergeProjections(
+        { data: { foo: true } },
+        { data: { bar: { baz: true } }, name: true },
+      ),
+      {
+        data: {
+          foo: true,
+          bar: { baz: true },
+        },
+        name: true,
+      },
+    );
+    assert.deepStrictEqual(
+      mergeProjections({ data: { foo: true } }, { data: true }),
+      { data: true },
     );
   });
 


### PR DESCRIPTION
## Summary

- push Graffy read projections into non-aggregate ClickHouse SQL for both ID and `$key` reads
- preserve the ID, version, and ordering values needed for refs, versions, and pagination cursors
- project nested JSON-encoded string fields with `JSONExtractRaw`
- project native ClickHouse `JSON` fields through direct subcolumns and rebuild only the requested nested shape
- merge projections across batched ID reads and retain `SELECT *` when no projection is supplied

## Why

The ClickHouse adapter always emitted `SELECT *`, even when the caller requested a small projection. Wide tracker/workLog rows therefore read and transferred columns that Graffy discarded after decoding.

## Local performance

Measured over 7,916 local Lego workLog rows, five runs per query:

- top-level projection reduced bytes read by 70.5% and response size by 64.3% compared with `SELECT *`
- nested projection on JSON encoded as `String` reduced response size by 54.8%; storage reads are unchanged because ClickHouse must read the full String column
- on an equivalent native `JSON` table, projecting only `data.component` reduced bytes read by 97.4% and median server time from 129.4 ms to 3.1 ms

## Validation

- 61 ClickHouse unit/integration/e2e tests pass against ClickHouse 26.4
- `npm run lint`
- `npm run typecheck`
- `npx knip --exclude files`
